### PR TITLE
支持哨兵模式

### DIFF
--- a/src/Cache/RedisCacheService.cs
+++ b/src/Cache/RedisCacheService.cs
@@ -37,6 +37,7 @@ namespace InitQ.Cache
 
         /// <summary>
         /// desc    redis连接对象初始化缓存服务
+        /// ps      通过传递过来的对象，直接支持哨兵模式
         /// author  hyz
         /// 
         /// </summary>

--- a/src/Cache/RedisCacheService.cs
+++ b/src/Cache/RedisCacheService.cs
@@ -35,6 +35,21 @@ namespace InitQ.Cache
             sub = connectionMultiplexer.GetSubscriber();
         }
 
+        /// <summary>
+        /// desc    redis连接对象初始化缓存服务
+        /// author  hyz
+        /// </summary>
+        /// <param name="connection"></param>
+        public RedisCacheService(ConnectionMultiplexer connection)
+        {
+            //设置线程池最小连接数
+            ThreadPool.SetMinThreads(200, 200);
+
+            connectionMultiplexer = connection;// ConnectionMultiplexer.Connect(options);
+            database = connectionMultiplexer.GetDatabase();
+            //通道广播
+            sub = connectionMultiplexer.GetSubscriber();
+        }
 
         public RedisCacheService(string configuration)
         {

--- a/src/Cache/RedisCacheService.cs
+++ b/src/Cache/RedisCacheService.cs
@@ -38,6 +38,7 @@ namespace InitQ.Cache
         /// <summary>
         /// desc    redis连接对象初始化缓存服务
         /// author  hyz
+        /// 
         /// </summary>
         /// <param name="connection"></param>
         public RedisCacheService(ConnectionMultiplexer connection)

--- a/src/ServiceCollectionExtensions.cs
+++ b/src/ServiceCollectionExtensions.cs
@@ -29,7 +29,7 @@ namespace InitQ
 
             services.Configure(setupAction);
 
-
+            // 依赖注入中提取ConnectionMultiplexerd对象，避免再次初始化
             var provider = services.BuildServiceProvider();
             var redisConn = provider.GetService<ConnectionMultiplexer>();
 
@@ -42,8 +42,6 @@ namespace InitQ
                 services.AddSingleton(typeof(ICacheService), new RedisCacheService(options.ConnectionString));
             }
 
-
-            //services.AddSingleton(typeof(ICacheService), new RedisCacheService(options.ConnectionString));
 
             services.AddHostedService<HostedService>();
 

--- a/src/ServiceCollectionExtensions.cs
+++ b/src/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 using InitQ.Cache;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using StackExchange.Redis;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -28,7 +29,20 @@ namespace InitQ
 
             services.Configure(setupAction);
 
-            services.AddSingleton(typeof(ICacheService), new RedisCacheService(options.ConnectionString));
+
+            var provider = services.BuildServiceProvider();
+            var redisConn = provider.GetService<ConnectionMultiplexer>();
+            if (redisConn != null)
+            {
+                services.AddSingleton(typeof(ICacheService), new RedisCacheService(redisConn));
+            }
+            else
+            {
+                services.AddSingleton(typeof(ICacheService), new RedisCacheService(options.ConnectionString));
+            }
+
+
+            //services.AddSingleton(typeof(ICacheService), new RedisCacheService(options.ConnectionString));
 
             services.AddHostedService<HostedService>();
 

--- a/src/ServiceCollectionExtensions.cs
+++ b/src/ServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ namespace InitQ
 
             var provider = services.BuildServiceProvider();
             var redisConn = provider.GetService<ConnectionMultiplexer>();
+
             if (redisConn != null)
             {
                 services.AddSingleton(typeof(ICacheService), new RedisCacheService(redisConn));


### PR DESCRIPTION
  在容器中提取ConnectionMultiplexer连接对象(单例),哨兵模式在客户端已实现；InitQ中直接使用对象一来可支持所有模式、同时避免在此初始化ConnectionMultiplexer连接